### PR TITLE
fixing low resolution

### DIFF
--- a/src/fdtdx_studio/ui/ui_elements/view_helper.js
+++ b/src/fdtdx_studio/ui/ui_elements/view_helper.js
@@ -11,6 +11,7 @@ export default {
         this.$nextTick(() => {
             const canvas = this.$refs.canvas;
             this.renderer = new THREE.WebGLRenderer({ canvas: canvas, alpha: true, antialias: true });
+            this.renderer.setPixelRatio(window.devicePixelRatio);
             this.renderer.setSize(120, 120);
             this.renderer.setClearColor(0x000000, 0);
 


### PR DESCRIPTION
resolves #20

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix low-resolution canvas rendering by matching the WebGL renderer pixel ratio to the device’s pixel ratio. The 120×120 preview now looks sharp on Retina/high‑DPI screens.

<sup>Written for commit 5b6cd65b1479d79c7d3fdd9384acb12758a866a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

